### PR TITLE
chore: Adds dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Canonical Ltd.
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  


### PR DESCRIPTION
# Description

Openapi is used by many of the SD-Core network functions and many of its dependencies are out of date and some contain known vulnerabilities. The goal of this PR is to use dependabot for automated dependency update, just like is done for all the other 5G core services.