### PR TITLE
Add inherited secrets to tag-github, push workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   tag-github:
     uses: omec-project/.github/.github/workflows/tag-github.yml@main
+    secrets: inherit
 
   update-version:
     needs: tag-github


### PR DESCRIPTION
The "tag-github" step was failing silently, causing downstream issues.