### PR TITLE
fix(nrfcache): match filters reject profiles they should accept

### DIFF
--- a/nrfcache/match_filters.go
+++ b/nrfcache/match_filters.go
@@ -34,6 +34,7 @@ var matchFilters = MatchFilters{
 	models.NFTYPE_PCF:  MatchPcfProfile,
 	models.NFTYPE_NSSF: MatchNssfProfile,
 	models.NFTYPE_UDM:  MatchUdmProfile,
+	models.NFTYPE_UDR:  MatchUdrProfile,
 	models.NFTYPE_AMF:  MatchAmfProfile,
 }
 
@@ -318,4 +319,28 @@ func MatchUdmProfile(profile *models.NFProfileDiscovery, opts Nnrf_NFDiscovery.A
 	// No SUPI filter - match any profile
 	logger.NrfcacheLog.Infof("udm match found = true (no SUPI filter)")
 	return true, nil
+}
+
+// MatchUdrProfile selects UDR profiles for a SUPI-filtered discovery.
+//
+// Without an entry in matchFilters a UDR profile is dropped unconditionally,
+// so a cached UDR lookup returns nothing and every UDM/PCF data access falls
+// through to a live NRF query. Rationale: UDR is resolved on every subscriber
+// data access, which makes it the most frequently discovered NF in the core.
+func MatchUdrProfile(profile *models.NFProfileDiscovery, opts Nnrf_NFDiscovery.ApiSearchNFInstancesRequest) (bool, error) {
+	supi := opts.GetSupi()
+	if supi == nil {
+		logger.NrfcacheLog.Debugf("udr match successful (no SUPI filter) for %s", profile.NfInstanceId)
+		return true, nil
+	}
+
+	// Unrestricted when no SUPI ranges are declared; see MatchPcfProfile.
+	if profile.UdrInfo == nil || len(profile.UdrInfo.GetSupiRanges()) == 0 {
+		logger.NrfcacheLog.Debugf("udr match successful (unrestricted: no SUPI ranges) for %s", profile.NfInstanceId)
+		return true, nil
+	}
+
+	matchFound := matchSupiRange(*supi, profile.UdrInfo.GetSupiRanges())
+	logger.NrfcacheLog.Debugf("udr match found = %v for %s", matchFound, profile.NfInstanceId)
+	return matchFound, nil
 }

--- a/nrfcache/match_filters.go
+++ b/nrfcache/match_filters.go
@@ -187,9 +187,10 @@ func extractSupiNumber(supi string) string {
 func MatchAusfProfile(profile *models.NFProfileDiscovery, opts Nnrf_NFDiscovery.ApiSearchNFInstancesRequest) (bool, error) {
 	supi := opts.GetSupi()
 	if supi != nil {
+		// Unrestricted when no SUPI ranges are declared; see MatchPcfProfile.
 		if profile.AusfInfo == nil || len(profile.AusfInfo.SupiRanges) == 0 {
-			logger.NrfcacheLog.Debugf("ausf match failed: no SUPI ranges for %s", profile.NfInstanceId)
-			return false, nil
+			logger.NrfcacheLog.Debugf("ausf match successful (unrestricted: no SUPI ranges) for %s", profile.NfInstanceId)
+			return true, nil
 		}
 
 		matchFound := matchSupiRange(*supi, profile.AusfInfo.SupiRanges)
@@ -279,9 +280,15 @@ func MatchAmfProfile(profile *models.NFProfileDiscovery, opts Nnrf_NFDiscovery.A
 func MatchPcfProfile(profile *models.NFProfileDiscovery, opts Nnrf_NFDiscovery.ApiSearchNFInstancesRequest) (bool, error) {
 	supi := opts.GetSupi()
 	if supi != nil {
+		// A profile declaring no SUPI ranges is unrestricted and serves every
+		// SUPI. The NRF's own discovery filter encodes this as an $or over
+		// "a range contains the SUPI" / "supiRanges is null" / "supiRanges is
+		// absent" (nrf producer/nf_discovery.go, [Query-18] supi). Rationale:
+		// the cache must select the same profiles as the NRF it caches,
+		// otherwise a cached lookup and a live discovery disagree.
 		if profile.PcfInfo == nil || len(profile.PcfInfo.SupiRanges) == 0 {
-			logger.NrfcacheLog.Infof("pcf match found = false (no SUPI ranges)")
-			return false, nil
+			logger.NrfcacheLog.Debugf("pcf match found = true (unrestricted: no SUPI ranges)")
+			return true, nil
 		}
 
 		matchFound := matchSupiRange(*supi, profile.PcfInfo.SupiRanges)
@@ -297,9 +304,10 @@ func MatchPcfProfile(profile *models.NFProfileDiscovery, opts Nnrf_NFDiscovery.A
 func MatchUdmProfile(profile *models.NFProfileDiscovery, opts Nnrf_NFDiscovery.ApiSearchNFInstancesRequest) (bool, error) {
 	supi := opts.GetSupi()
 	if supi != nil {
+		// Unrestricted when no SUPI ranges are declared; see MatchPcfProfile.
 		if profile.UdmInfo == nil || len(profile.UdmInfo.GetSupiRanges()) == 0 {
-			logger.NrfcacheLog.Infof("udm match found = false (no SUPI ranges)")
-			return false, nil
+			logger.NrfcacheLog.Debugf("udm match found = true (unrestricted: no SUPI ranges)")
+			return true, nil
 		}
 
 		matchFound := matchSupiRange(*supi, profile.UdmInfo.GetSupiRanges())

--- a/nrfcache/nrfcache_test.go
+++ b/nrfcache/nrfcache_test.go
@@ -1158,9 +1158,9 @@ func TestMatchProfileWithoutSupiRangesIsUnrestricted(t *testing.T) {
 	const supi = "imsi-208930100007500"
 
 	testCases := []struct {
-		name    string
-		matcher MatchFilter
 		profile models.NFProfileDiscovery
+		matcher MatchFilter
+		name    string
 	}{
 		{
 			name:    "udm_info_without_supi_ranges",

--- a/nrfcache/nrfcache_test.go
+++ b/nrfcache/nrfcache_test.go
@@ -1147,3 +1147,106 @@ func TestAmfProfileMatching(t *testing.T) {
 		})
 	}
 }
+
+// TestMatchProfileWithoutSupiRangesIsUnrestricted covers profiles that declare
+// no SUPI ranges. Such a profile serves every SUPI, so a SUPI-filtered
+// discovery must select it. The NRF's own discovery filter encodes this as an
+// $or over "a range contains the SUPI" / "supiRanges is null" / "supiRanges is
+// absent"; a matcher that rejected these profiles would make cached lookups
+// disagree with a live discovery against the same NRF.
+func TestMatchProfileWithoutSupiRangesIsUnrestricted(t *testing.T) {
+	const supi = "imsi-208930100007500"
+
+	testCases := []struct {
+		name    string
+		matcher MatchFilter
+		profile models.NFProfileDiscovery
+	}{
+		{
+			name:    "udm_info_without_supi_ranges",
+			matcher: MatchUdmProfile,
+			profile: models.NFProfileDiscovery{
+				NfInstanceId: "UDM-no-ranges",
+				NfType:       models.NFTYPE_UDM,
+				UdmInfo:      &models.UdmInfo{},
+			},
+		},
+		{
+			name:    "udm_info_absent",
+			matcher: MatchUdmProfile,
+			profile: models.NFProfileDiscovery{
+				NfInstanceId: "UDM-no-info",
+				NfType:       models.NFTYPE_UDM,
+			},
+		},
+		{
+			name:    "pcf_info_without_supi_ranges",
+			matcher: MatchPcfProfile,
+			profile: models.NFProfileDiscovery{
+				NfInstanceId: "PCF-no-ranges",
+				NfType:       models.NFTYPE_PCF,
+				PcfInfo:      &models.PcfInfo{},
+			},
+		},
+		{
+			name:    "pcf_info_absent",
+			matcher: MatchPcfProfile,
+			profile: models.NFProfileDiscovery{
+				NfInstanceId: "PCF-no-info",
+				NfType:       models.NFTYPE_PCF,
+			},
+		},
+		{
+			name:    "ausf_info_without_supi_ranges",
+			matcher: MatchAusfProfile,
+			profile: models.NFProfileDiscovery{
+				NfInstanceId: "AUSF-no-ranges",
+				NfType:       models.NFTYPE_AUSF,
+				AusfInfo:     &models.AusfInfo{},
+			},
+		},
+		{
+			name:    "ausf_info_absent",
+			matcher: MatchAusfProfile,
+			profile: models.NFProfileDiscovery{
+				NfInstanceId: "AUSF-no-info",
+				NfType:       models.NFTYPE_AUSF,
+			},
+		},
+	}
+
+	param := Nnrf_NFDiscovery.ApiSearchNFInstancesRequest{}.Supi(supi)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			match, err := tc.matcher(&tc.profile, param)
+			if err != nil {
+				t.Fatalf("matcher returned error: %v", err)
+			}
+			if !match {
+				t.Errorf("profile %s declares no SUPI ranges and must match SUPI %s, got no match",
+					tc.profile.NfInstanceId, supi)
+			}
+		})
+	}
+}
+
+// TestMatchProfileWithSupiRangesStillFiltersOut guards the complementary case:
+// once a profile declares ranges, a SUPI outside them must not match.
+func TestMatchProfileWithSupiRangesStillFiltersOut(t *testing.T) {
+	ranges := []models.SupiRange{{Start: openapi.PtrString("100000000000000"), End: openapi.PtrString("100000000000009")}}
+	param := Nnrf_NFDiscovery.ApiSearchNFInstancesRequest{}.Supi("imsi-208930100007500")
+
+	profile := models.NFProfileDiscovery{
+		NfInstanceId: "UDM-ranged",
+		NfType:       models.NFTYPE_UDM,
+		UdmInfo:      &models.UdmInfo{SupiRanges: ranges},
+	}
+	match, err := MatchUdmProfile(&profile, param)
+	if err != nil {
+		t.Fatalf("MatchUdmProfile returned error: %v", err)
+	}
+	if match {
+		t.Error("SUPI outside the declared ranges must not match")
+	}
+}

--- a/nrfcache/nrfcache_test.go
+++ b/nrfcache/nrfcache_test.go
@@ -1213,6 +1213,23 @@ func TestMatchProfileWithoutSupiRangesIsUnrestricted(t *testing.T) {
 				NfType:       models.NFTYPE_AUSF,
 			},
 		},
+		{
+			name:    "udr_info_without_supi_ranges",
+			matcher: MatchUdrProfile,
+			profile: models.NFProfileDiscovery{
+				NfInstanceId: "UDR-no-ranges",
+				NfType:       models.NFTYPE_UDR,
+				UdrInfo:      &models.UdrInfo{},
+			},
+		},
+		{
+			name:    "udr_info_absent",
+			matcher: MatchUdrProfile,
+			profile: models.NFProfileDiscovery{
+				NfInstanceId: "UDR-no-info",
+				NfType:       models.NFTYPE_UDR,
+			},
+		},
 	}
 
 	param := Nnrf_NFDiscovery.ApiSearchNFInstancesRequest{}.Supi(supi)
@@ -1248,5 +1265,43 @@ func TestMatchProfileWithSupiRangesStillFiltersOut(t *testing.T) {
 	}
 	if match {
 		t.Error("SUPI outside the declared ranges must not match")
+	}
+}
+
+// TestUdrProfileIsSelectableFromCache guards the registration of UDR in
+// matchFilters. A profile whose NfType has no registered filter is dropped by
+// NrfCache.get, so an unregistered UDR made every cached UDR lookup return
+// empty and forced a live NRF query on every subscriber data access.
+func TestUdrProfileIsSelectableFromCache(t *testing.T) {
+	if _, ok := matchFilters[models.NFTYPE_UDR]; !ok {
+		t.Fatal("UDR has no entry in matchFilters, so cached UDR discovery can never return a profile")
+	}
+
+	profile := models.NFProfileDiscovery{
+		NfInstanceId: "UDR-1",
+		NfType:       models.NFTYPE_UDR,
+		UdrInfo: &models.UdrInfo{
+			SupiRanges: []models.SupiRange{
+				{Start: openapi.PtrString("208930100007500"), End: openapi.PtrString("208930100007599")},
+			},
+		},
+	}
+
+	inRange := Nnrf_NFDiscovery.ApiSearchNFInstancesRequest{}.Supi("imsi-208930100007550")
+	match, err := MatchUdrProfile(&profile, inRange)
+	if err != nil {
+		t.Fatalf("MatchUdrProfile returned error: %v", err)
+	}
+	if !match {
+		t.Error("SUPI inside the declared range must match")
+	}
+
+	outOfRange := Nnrf_NFDiscovery.ApiSearchNFInstancesRequest{}.Supi("imsi-208930100009999")
+	match, err = MatchUdrProfile(&profile, outOfRange)
+	if err != nil {
+		t.Fatalf("MatchUdrProfile returned error: %v", err)
+	}
+	if match {
+		t.Error("SUPI outside the declared range must not match")
 	}
 }


### PR DESCRIPTION
Two related defects in `nrfcache/match_filters.go`. Both make cached NF discovery return empty for profiles that are valid, so the cache is structurally incapable of hitting and every lookup falls through to the NRF.

Both were found and measured against a live Aether SD-Core deployment under registration load, with a 5G SA gNB/UE simulator driving attaches.

## 1 — Profiles without SUPI ranges are treated as restricted

`MatchUdmProfile` / `MatchPcfProfile` / `MatchAusfProfile` require a cached profile to carry a non-empty `SupiRanges` whenever the discovery query includes a `supi`; a profile with no ranges is rejected.

SD-Core registers one UDM/PCF serving every subscriber, with no SUPI ranges — verified on the wire, the NRF returns `udmInfo:{"groupId":""}`. So the match can never succeed, and the AMF logs `cache miss for nftype AUSF/UDM/PCF` on every attach, preceded by `match found = false (no SUPI ranges)`.

Per TS 29.510 `supiRanges` is an optional restriction on an NF profile: a range constrains, and an absent constraint admits everything. The matchers now treat "no SUPI ranges" as unrestricted.

## 2 — No match filter is registered for UDR

`matchFilters` has no `NFTYPE_UDR` entry, and `nrfcache.go` silently drops any profile whose NfType has no filter. Cached UDR discovery therefore always returns empty — a permanent miss — after which the `EnableNrfCaching && empty` fallback fires a second, direct NRF query. The UDM performs several UDR discoveries per registration, so this sits on the attach hot path.

## Measured effect

Registering the UDR filter took the test deployment from 22 to ~185 registrations/s (stable across 5 runs, 173–189/s, 100% success), registration P50 400 ms → 256 ms, and MongoDB operations per attach 50 → 25 as `NfProfile` and `urilist` queries left the hot path. The SUPI-range fix removes the remaining per-attach AUSF/UDM/PCF misses (4 → 0 observed).

## Testing

Regression tests added for both defects; each fails without its fix. `go test ./nrfcache/` passes.

Validated live by building the consuming NFs (AMF, UDM) against this branch with a `go mod edit -replace` and re-measuring on the deployment.

The two changes share `nrfcache_test.go` and the second builds on the first, hence one PR; happy to split if preferred.