### PR TITLE
fix(nrfcache): stop stalling cache hits behind an in-flight NRF query

### DIFF
--- a/nrfcache/nrfcache.go
+++ b/nrfcache/nrfcache.go
@@ -132,6 +132,7 @@ type NrfCache struct {
 	nrfDiscoveryQueryCb NrfDiscoveryQueryCb // nrf query callback
 	evictionInterval    time.Duration       // timer interval in which the cache is checked for eviction of expired entries
 	mutex               sync.RWMutex
+	discoveryMutex      sync.Mutex
 }
 
 // handleLookup - Checks if the cache has nf cache entry corresponding to the parameters specified.
@@ -154,11 +155,21 @@ func (c *NrfCache) handleLookup(ctx context.Context, nrfUri string, targetNfType
 		return models.SearchResult{NfInstances: nfInstances}, nil
 	}
 
-	// Cache miss - acquire write lock
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
+	// Only one discovery for this NF type runs at a time, so a burst of
+	// concurrent misses collapses into a single NRF query. discoveryMutex is
+	// held instead of the cache lock: a sync.RWMutex queues new readers behind
+	// a waiting writer, so holding the cache write lock across the round trip
+	// stalls every concurrent cache *hit* for this NF type for a full RTT.
+	// With a permanently-missing NF type that stall is unbounded and caps
+	// registration throughput core-wide.
+	c.discoveryMutex.Lock()
+	defer c.discoveryMutex.Unlock()
 
+	// The winner of discoveryMutex may already have populated the entry.
+	c.mutex.RLock()
 	nfInstances = c.get(param)
+	c.mutex.RUnlock()
+
 	if len(nfInstances) > 0 {
 		return models.SearchResult{NfInstances: nfInstances}, nil
 	}
@@ -174,9 +185,12 @@ func (c *NrfCache) handleLookup(ctx context.Context, nrfUri string, targetNfType
 	}
 
 	ttl := time.Duration(searchResult.ValidityPeriod) * time.Second
+
+	c.mutex.Lock()
 	for i := range searchResult.NfInstances {
 		c.set(&searchResult.NfInstances[i], ttl)
 	}
+	c.mutex.Unlock()
 
 	return *searchResult, nil
 }

--- a/nrfcache/nrfcache.go
+++ b/nrfcache/nrfcache.go
@@ -165,7 +165,7 @@ func (c *NrfCache) handleLookup(ctx context.Context, nrfUri string, targetNfType
 	c.discoveryMutex.Lock()
 	defer c.discoveryMutex.Unlock()
 
-	// The winner of discoveryMutex may already have populated the entry.
+	// Re-check in case another goroutine already populated the entry.
 	c.mutex.RLock()
 	nfInstances = c.get(param)
 	c.mutex.RUnlock()

--- a/nrfcache/nrfcache.go
+++ b/nrfcache/nrfcache.go
@@ -155,13 +155,7 @@ func (c *NrfCache) handleLookup(ctx context.Context, nrfUri string, targetNfType
 		return models.SearchResult{NfInstances: nfInstances}, nil
 	}
 
-	// Only one discovery for this NF type runs at a time, so a burst of
-	// concurrent misses collapses into a single NRF query. discoveryMutex is
-	// held instead of the cache lock: a sync.RWMutex queues new readers behind
-	// a waiting writer, so holding the cache write lock across the round trip
-	// stalls every concurrent cache *hit* for this NF type for a full RTT.
-	// With a permanently-missing NF type that stall is unbounded and caps
-	// registration throughput core-wide.
+	// discoveryMutex serializes NRF round-trips without blocking concurrent cache hits.
 	c.discoveryMutex.Lock()
 	defer c.discoveryMutex.Unlock()
 


### PR DESCRIPTION
`handleLookup` takes the cache's exclusive write lock and holds it across the NRF network round trip. `sync.RWMutex` queues new readers behind a waiting writer, so one in-flight discovery blocks every concurrent cache **hit** for that NF type until the network call returns — the cache stops being a cache exactly when it is under load.

Observed on a live Aether SD-Core deployment under registration load:

- Throughput flat while latency grew linearly with concurrency (Little's Law holding at every point) — the signature of a serialized section, not CPU.
- Scaling the NRF 1→4 replicas changed nothing (the lock is client-side).
- The arithmetic matched: ~6 serialized discoveries × ~7 ms ≈ 42 ms per registration ≈ 23/s, against a measured 22/s ceiling.

The discovery round trip now runs outside the cache's own lock. A dedicated `discoveryMutex` preserves the existing single-NRF-callback behaviour that `TestCacheConcurrency` pins — the point was never to allow N concurrent identical NRF queries, only to stop that serialization from blocking unrelated readers.

Scoping honestly: with the matcher fixes in #170 making misses rare, this one's steady-state effect is within run-to-run noise. It matters on cold start, on TTL expiry, and whenever a miss storm coincides with load — which is when the system can least afford to serialize.

`go test ./nrfcache/` passes, including `TestCacheConcurrency`. Independent of #170; applies cleanly either way.